### PR TITLE
fix error in Moodle 3.4+ where the 'object' class was removed

### DIFF
--- a/student/view.php
+++ b/student/view.php
@@ -211,7 +211,7 @@ function show_register_feed( $bim, $userid, $cm) {
     if ( $mform->is_cancelled() ) {
         print( "cancelled" );
     } else if ( $fromform = $mform->get_data() ) {
-        $response = new object();
+        $response = new stdClass();
         $response->blogurl = $fromform->blogurl;
 
         $response->bim = $bim->id;


### PR DESCRIPTION
For PHP 7.2 compatibility. Refer to HQ issues MDL-60281 and MDL-52471.