### PR TITLE
emit the page footer when registering a feed as a student

### DIFF
--- a/student/view.php
+++ b/student/view.php
@@ -44,7 +44,6 @@ function show_student( $bim, $userid, $cm, $course) {
     if ( ! bim_feed_exists( $bimid, $userid ) ) {
         // need to check for passing in of parameters
         show_register_feed( $bim, $userid, $cm );
-        return;
     } else {
         $screen = optional_param( 'screen', '', PARAM_ALPHA );
         if ( $screen == "showQuestions" ) {


### PR DESCRIPTION
Presently a student with no feed registered will receive a page likely without blocks and with non-functional javascript elements because `echo $OUTPUT->footer();` isn't called.